### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -27,7 +27,7 @@ CurrentIndex	KEYWORD2
 Next	KEYWORD2
 AtEnd	KEYWORD2
 Previous	KEYWORD2
-ReverseIterator KEYWORD1
+ReverseIterator	KEYWORD1
 CommandHandler	KEYWORD1
 Process	KEYWORD2
 AddCommand	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords