### PR TITLE
Shut up compile reorder warnings

### DIFF
--- a/utility/CommandDispatcherBase.cpp
+++ b/utility/CommandDispatcherBase.cpp
@@ -5,8 +5,8 @@ using namespace MLP;
 
 
 CommandDispatcherBase::CommandDispatcherBase( CommandCallback *pCallbackBuffer, uint8_t uCallbackBufferLength, VariableMap *pVariableMapBuffer, uint8_t uVariableMapLength)
-  : m_uMaxCommands(uCallbackBufferLength), m_pCommands(pCallbackBuffer)
-  , m_uMaxVariables(uVariableMapLength), m_pVariableMap(pVariableMapBuffer)
+  : m_pCommands(pCallbackBuffer), m_uMaxCommands(uCallbackBufferLength)
+  , m_pVariableMap(pVariableMapBuffer), m_uMaxVariables(uVariableMapLength)
 {
   m_uLastCommand = 0;
   m_uLastVariable = 0;

--- a/utility/MegunoLinkProtocol.cpp
+++ b/utility/MegunoLinkProtocol.cpp
@@ -3,34 +3,34 @@
 
 
 MegunoLinkProtocol::MegunoLinkProtocol( const __FlashStringHelper *Context )
-  : m_pfchContext((PROGMEM const char*)Context), m_bFlashString(false), m_ChannelName(NULL), m_rDestination(Serial)
+  : m_pfchContext((PROGMEM const char*)Context), m_ChannelName(NULL), m_bFlashString(false), m_rDestination(Serial)
 {
 }
 
 MegunoLinkProtocol::MegunoLinkProtocol( const __FlashStringHelper *Context, const char *Channel )
-  : m_pfchContext((PROGMEM const char*)Context), m_bFlashString(false), m_ChannelName(Channel), m_rDestination(Serial)
+  : m_pfchContext((PROGMEM const char*)Context), m_ChannelName(NULL), m_bFlashString(false), m_rDestination(Serial)
 {
 
 }
 
 MegunoLinkProtocol::MegunoLinkProtocol( const __FlashStringHelper *Context, const __FlashStringHelper *Channel )
-  : m_pfchContext((PROGMEM const char*)Context), m_bFlashString(true), m_ChannelName((PROGMEM const char*)Channel), m_rDestination(Serial)
+  : m_pfchContext((PROGMEM const char*)Context), m_ChannelName(Channel), m_bFlashString(true), m_rDestination(Serial)
 {
 }
 
 MegunoLinkProtocol::MegunoLinkProtocol( const __FlashStringHelper *Context, Print &rDestination )
-  : m_pfchContext((PROGMEM const char*)Context), m_bFlashString(false), m_ChannelName(NULL), m_rDestination(rDestination)
+  : m_pfchContext((PROGMEM const char*)Context), m_ChannelName(NULL), m_bFlashString(false), m_rDestination(rDestination)
 {
 }
 
 MegunoLinkProtocol::MegunoLinkProtocol( const __FlashStringHelper *Context, const char *Channel, Print &rDestination )
-  : m_pfchContext((PROGMEM const char*)Context), m_bFlashString(false), m_ChannelName(Channel), m_rDestination(rDestination)
+  : m_pfchContext((PROGMEM const char*)Context), m_ChannelName(Channel), m_bFlashString(false), m_rDestination(rDestination)
 {
 
 }
 
 MegunoLinkProtocol::MegunoLinkProtocol( const __FlashStringHelper *Context, const __FlashStringHelper *Channel, Print &rDestination )
-  : m_pfchContext((PROGMEM const char*)Context), m_bFlashString(true), m_ChannelName((PROGMEM const char*)Channel), m_rDestination(rDestination)
+  : m_pfchContext((PROGMEM const char*)Context), m_ChannelName((PROGMEM const char*)Channel), m_bFlashString(true), m_rDestination(rDestination)
 {
 }
 

--- a/utility/MegunoLinkProtocol.h
+++ b/utility/MegunoLinkProtocol.h
@@ -4,10 +4,10 @@
 
 class MegunoLinkProtocol
 {
+  const char * const m_pfchContext;
+
   const void *m_ChannelName;
   const bool m_bFlashString;
-
-  const char * const m_pfchContext;
 
 protected:
   Print &m_rDestination;

--- a/utility/StreamParser.cpp
+++ b/utility/StreamParser.cpp
@@ -9,18 +9,18 @@ StreamParser::StreamParser( MLP::CommandDispatcherBase &rCommandHandler,
                            char chStartOfMessage /*= '!'*/, 
                            char chEndOfMessage /*= '\r'*/ )
                            : m_pCommandHandler(&rCommandHandler)
+                           , m_pSource(&rSourceStream)
                            , m_chStartOfMessage(chStartOfMessage)
                            , m_chEndOfMessage(chEndOfMessage)
-                           , m_uMaxBufferSize(uBufferSize)
                            , m_pchBuffer(pchReceiveBuffer)
-                           , m_pSource(&rSourceStream)
+                           , m_uMaxBufferSize(uBufferSize)
 {
   Reset();
 }
 
 StreamParser::StreamParser(char *pchReceiveBuffer, unsigned uBufferSize)
-  : m_uMaxBufferSize(uBufferSize)
-  , m_pchBuffer(pchReceiveBuffer)
+  : m_pchBuffer(pchReceiveBuffer)
+  , m_uMaxBufferSize(uBufferSize)
 {
   Reset();
 }

--- a/utility/StreamParser.h
+++ b/utility/StreamParser.h
@@ -8,6 +8,8 @@ namespace MLP
   class StreamParser
   {
   protected:
+    MLP::CommandDispatcherBase *m_pCommandHandler;
+
     // The stream that we are parsing for commands. 
     // Protected so that network command handlers (such as TCPCommandHandler)
     // can update with connection. If null, commands are not parsed. 
@@ -18,8 +20,6 @@ namespace MLP
     // The buffer is reset when a start character is received. Commands
     // are dispatched when the end character is received. 
     char m_chStartOfMessage, m_chEndOfMessage;
-
-    MLP::CommandDispatcherBase *m_pCommandHandler;
 
   private:
     // A buffer to collect commands. Buffer, and size, is provided. 


### PR DESCRIPTION
This brings back correct initialization and shuts the compiler
` error: 'xxxx' will be initialized after [-Werror=reorder]`
warning.