### PR TITLE
Fix compilation warnings when using the STM32Duino Core

### DIFF
--- a/utility/InterfacePanel.cpp
+++ b/utility/InterfacePanel.cpp
@@ -18,14 +18,14 @@ InterfacePanel::InterfacePanel(const __FlashStringHelper *channelName, Print &rD
 
 }
 
-void InterfacePanel::SetText(const __FlashStringHelper *ControlName, float Value, uint8_t DecimalPlaces)
+void InterfacePanel::SetText(const __FlashStringHelper *ControlName, float Value, int DecimalPlaces)
 {
   SendTextHeader(ControlName);
   m_rDestination.print(Value, DecimalPlaces);
   SendDataTail();
 }
 
-void InterfacePanel::SetText(const char *ControlName, float Value, uint8_t DecimalPlaces)
+void InterfacePanel::SetText(const char *ControlName, float Value, int DecimalPlaces)
 {
   SendTextHeader(ControlName);
   m_rDestination.print(Value, DecimalPlaces);

--- a/utility/InterfacePanel.h
+++ b/utility/InterfacePanel.h
@@ -42,8 +42,8 @@ public:
     SendDataTail();
   }
 
-  void SetText(const __FlashStringHelper *ControlName, float Value, uint8_t DecimalPlaces);
-  void SetText(const char *ControlName, float Value, uint8_t DecimalPlaces);
+  void SetText(const __FlashStringHelper *ControlName, float Value, int DecimalPlaces);
+  void SetText(const char *ControlName, float Value, int DecimalPlaces);
 
   template<class T>
   void SetNumber(const char *ControlName, T Value)

--- a/utility/Plot.cpp
+++ b/utility/Plot.cpp
@@ -145,7 +145,7 @@ void Plot::HideCursor(const __FlashStringHelper* SeriesName)
   ShowCursor(SeriesName, false);
 }
 
-void Plot::SetCursorPosition(const char* SeriesName, double dPosition, uint8_t nPrecision)
+void Plot::SetCursorPosition(const char* SeriesName, double dPosition, int nPrecision)
 {
   SendDataHeader(F("C-POS"));
   m_rDestination.print(SeriesName);
@@ -154,7 +154,7 @@ void Plot::SetCursorPosition(const char* SeriesName, double dPosition, uint8_t n
   SendDataTail();
 }
 
-void Plot::SetCursorPosition(const __FlashStringHelper* SeriesName, double dPosition, uint8_t nPrecision)
+void Plot::SetCursorPosition(const __FlashStringHelper* SeriesName, double dPosition, int nPrecision)
 {
   SendDataHeader(F("C-POS"));
   m_rDestination.print(SeriesName);

--- a/utility/Plot.h
+++ b/utility/Plot.h
@@ -91,8 +91,8 @@ public:
   void ShowCursor(const __FlashStringHelper* SeriesName, bool bVisible = true);
   void HideCursor(const __FlashStringHelper* SeriesName);
 
-  void SetCursorPosition(const char* SeriesName, double dPosition, uint8_t nPrecision = 5);
-  void SetCursorPosition(const __FlashStringHelper* SeriesName, double dPosition, uint8_t nPrecision = 5);
+  void SetCursorPosition(const char* SeriesName, double dPosition, int nPrecision = 5);
+  void SetCursorPosition(const __FlashStringHelper* SeriesName, double dPosition, int nPrecision = 5);
 
 protected:
   Plot(const __FlashStringHelper *Context, Print &rDestination = Serial);

--- a/utility/RecordTable.h
+++ b/utility/RecordTable.h
@@ -8,7 +8,7 @@ enum class SpecialParameters
 
 class RecordTable : public MegunoLinkProtocol
 {
-  uint8_t m_uNumberOfDecimalPlaces;
+  int m_uNumberOfDecimalPlaces;
 
 public:
   RecordTable(Print& rDestination = Serial);


### PR DESCRIPTION
I am using MegunoLink with a NUCLEO development board and the STM32Duino core in Platformio. Everything is working fine except that the compiler generate a couple of warnings.

Here is an example of the warning that I got :
```
In file included from .pio\libdeps\nucleo_f303re\MegunoLink/MegunoLink.h:9,
                 from src\modules\interface.cpp:2:
.pio\libdeps\nucleo_f303re\MegunoLink/utility/RecordTable.h: In member function 'void RecordTable::SendValue(float)':
.pio\libdeps\nucleo_f303re\MegunoLink/utility/RecordTable.h:139:57: warning: ISO C++ says that these are ambiguous, even though the worst conversion for the first is better than the worst conversion for the second:  
  139 |     m_rDestination.print(Value, m_uNumberOfDecimalPlaces);
      |  
```

I found that at some place in the library `Print::print(double, int)` is use with an `uint8_t` as the second argument. Changing these argument ton an `int` make the warnings go away.