### PR TITLE
Update Filter.h

### DIFF
--- a/Filter.h
+++ b/Filter.h
@@ -13,7 +13,7 @@ template<class T> class ExponentialFilter
 
 public:
   ExponentialFilter(T WeightNew, T Initial)
-    : m_WeightNew(WeightNew), m_Current(Initial)
+    : m_WeightNew(WeightNew), m_Current(Initial*100)
   { }
 
   void Filter(T New)


### PR DESCRIPTION
the SetCurrent() method multiplies the NewValue by 100.   If the constructor is used instead of the method, then the m_Current variable is never multiplied by 100 and causes the Filter() method to calculate the wrong value.  

This issue can be replicated by using a small weight (20)  and passing in the initial value in the constructor.